### PR TITLE
Add base styling for reservations table

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,4 +4,5 @@
 @import "base";
 @import "skeleton";
 @import "components/nav";
+@import "components/table";
 @import "sections/home";

--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -1,0 +1,37 @@
+.reservations {
+  width: 90%;
+  margin: 0 auto;
+  .head {
+    display: flex;
+    width: 96%;
+    justify-content: space-between;
+    margin: 0 5px;
+    article {
+      width: 18%;
+      font-size: 20px;
+    }
+  }
+  .row {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    &:nth-child(even) {
+      article {
+        background: $purple;
+      }
+    }
+    &:nth-child(odd) {
+      article {
+        background: $accent;
+      }
+    }
+    article {
+      width: 18%;
+      color: $light;
+      margin: 10px 0;
+      text-align: center;
+      padding: 5px;
+      font-size: 14px;
+    }
+  }
+}

--- a/app/views/layouts/table.html.haml
+++ b/app/views/layouts/table.html.haml
@@ -1,0 +1,20 @@
+%article.reservations
+  %section.head
+    %article Reservation
+    %article Host
+    %article Location
+    %article From
+    %article To
+
+  - 10.times do
+    %section.row
+      %article
+        = rand(1000) + 1
+      %article
+        = Faker::HarryPotter.character
+      %article
+        = Faker::HarryPotter.location
+      %article
+        = Faker::Date.between(2.years.ago, Date.today + 1.year)
+      %article
+        = Faker::Date.between(2.years.ago, Date.today + 1.year)


### PR DESCRIPTION
@ski-climb @njgheorghita @Sh1pley @riverswb 

Basic flexbox styling for what we will end up using for a reservations
index show.

<img width="974" alt="screen shot 2017-02-08 at 6 57 31 am" src="https://cloud.githubusercontent.com/assets/19894032/22740330/87f76e2e-edcc-11e6-92b5-e978ba41eade.png">


I developed this on the home page and then moved it to a separate
`table.html.haml` file.

Let me know if you want to see any changes.

Closes #22