### PR TITLE
61 ne night scopes

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -2,7 +2,7 @@ class ReservationsController < ApplicationController
   def create
     reservation = Reservation.new(reservation_params)
     reservation.confirmed!
-    nights = Night.where(couch_id: night_params["couch_id"]).where(date: Date.parse(params["check_in"])..Date.parse(params["check_out"]) - 1.day)
+    nights = Night.all_for_couch(night_params["couch_id"]).between_check_in_check_out(night_params["check_in"], night_params["check_out"])
     reservation.nights << nights
     reservation.save
     flash[:success] = "#{Couch.find(params["couch_id"]).name} reserved for #{params["check_in"]}."

--- a/app/models/night.rb
+++ b/app/models/night.rb
@@ -2,4 +2,7 @@ class Night < ApplicationRecord
   validates_presence_of :date
   belongs_to :couch
   belongs_to :reservation
+
+  scope :all_for_couch, -> (couch) { where(couch: couch) }
+  scope :between_check_in_check_out, -> (check_in, check_out) { where(date: (Date.parse(check_in))..(Date.parse(check_out) - 1.day)) }
 end

--- a/spec/factories/nights.rb
+++ b/spec/factories/nights.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :night do
-    date { Date.current }
+    date { Faker::Date.between(2.weeks.ago, 2.weeks.from_now) }
     reservation
     couch 
   end

--- a/spec/features/reservations/traveler_can_make_a_reservation_spec.rb
+++ b/spec/features/reservations/traveler_can_make_a_reservation_spec.rb
@@ -16,7 +16,7 @@ describe "Traveler" do
     let!(:traveler) { create(:user) }
     let!(:couch_1)  { create(:couch) }
     let!(:couch_2)  { create(:couch, city: "Mike's Hometown") }
-    let!(:today)  { Date.today }
+    let!(:today)  { Date.current }
     let!(:tomorrow)  { Date.tomorrow }
     before do 
       visit root_path

--- a/spec/models/night_spec.rb
+++ b/spec/models/night_spec.rb
@@ -9,4 +9,28 @@ describe Night do
     it { is_expected.to belong_to(:reservation) }
     it { is_expected.to belong_to(:couch) }
   end
+
+  describe ".all_for_couch" do
+    let!(:couch_1) { create(:couch, city: "Jamestown") }
+    let!(:couch_2) { create(:couch, city: "Newport") }
+
+    it "returns only the nights for the given couch" do
+      couch_1.nights << create_list(:night, 5, couch: couch_1)
+      couch_2.nights << create_list(:night, 6, couch: couch_2)
+
+      expect(Night.all_for_couch(couch_1.id).count).to eq 5
+      expect(Night.all_for_couch(couch_1.id)).to match_array couch_1.nights
+    end
+  end
+
+  describe ".between_check_in_check_out" do
+    it "returns all nights between the check in and check out but not including the check out" do
+      today = Date.current
+      check_out_day = today + 5.days
+      3.times { |n| create(:night, date: today + n) }
+      4.times { |n| create(:night, date: today + 4.days + n) }
+
+      expect(Night.between_check_in_check_out(today.to_s, check_out_day.to_s).count).to eq 4
+    end
+  end
 end


### PR DESCRIPTION
closes #61 

These are convenience scopes which I imagine that we'll use quite a bit.  Bonus - they're chainable.

One thing to note is that the `.between_check_in_check_out` scope would only return nights between those days, but *will not include the check out date*.

As an aside, since the scopes were originally getting used in a controller, the check in and check out date arguments are taken in as strings, not date objects ("2017-02-22", not "Date.current").  I'm open to swapping that out - just built it for the current use.  

@tmikeschu, @Sh1pley, @njgheorghita, @riverswb Ready for review!