### PR TITLE
Add vanilla form styling to new couch

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,4 +8,4 @@
 @import "components/nav";
 @import "components/table";
 @import "sections/home";
-@import "sections/account_form";
+@import "sections/vanilla_form";

--- a/app/assets/stylesheets/sections/_vanilla_form.scss
+++ b/app/assets/stylesheets/sections/_vanilla_form.scss
@@ -1,4 +1,4 @@
-.account_form {
+.vanilla_form {
   width: 60%;
   margin: 10% auto;
   text-align: center;

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,4 +1,4 @@
-%section.account_form
+%section.vanilla_form
   %h1 Log Into Pad Crash
   %article
     = form_for :session, :url => "/login" do |f|

--- a/app/views/users/couches/new.html.haml
+++ b/app/views/users/couches/new.html.haml
@@ -1,28 +1,30 @@
-%h1 Add Couch
-%br
-= form_for [@user, @couch] do |f|
-  = f.label :name
+%section.vanilla_form
+  %h1 Add Couch
   %br
-  = f.text_field :name
-  %br
-  = f.label :description
-  %br
-  = f.text_area :description
-  %br
-  = f.label :street_address
-  %br
-  = f.text_area :street_address
-  %br
-  = f.label :city
-  %br
-  = f.text_area :city
-  %br
-  = f.label :state
-  %br
-  = f.text_area :state
-  %br
-  = f.label :zipcode
-  %br
-  = f.text_area :zipcode
-  %br
-  = f.submit "Add Couch"
+  %article
+    = form_for [@user, @couch] do |f|
+      = f.label :name
+      %br
+      = f.text_field :name
+      %br
+      = f.label :description
+      %br
+      = f.text_field :description
+      %br
+      = f.label :street_address
+      %br
+      = f.text_field :street_address
+      %br
+      = f.label :city
+      %br
+      = f.text_field :city
+      %br
+      = f.label :state
+      %br
+      = f.text_field :state
+      %br
+      = f.label :zipcode
+      %br
+      = f.text_field :zipcode
+      %br
+      = f.submit "Add Couch"

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,4 +1,4 @@
-%section.account_form  
+%section.vanilla_form  
   %h1 Create your Pad Crash Account
   %br
   %article

--- a/spec/features/reservations/traveler_can_make_a_reservation_spec.rb
+++ b/spec/features/reservations/traveler_can_make_a_reservation_spec.rb
@@ -15,7 +15,7 @@ describe "Traveler" do
   describe "As a registered user" do
     let!(:traveler) { create(:user) }
     let!(:couch_1)  { create(:couch, city: "Another City") }
-    let!(:couch_2)  { create(:couch, city: "Mike's Hometown") }
+    let!(:couch_2)  { create(:couch, city: "Mike's Hometown", name: "CRAZY NAME") }
     let!(:today)  { Date.current }
     let!(:tomorrow)  { Date.tomorrow }
     before do 


### PR DESCRIPTION
Vanilla styling added to the create a couch view. The only thing i'm not super satisfied with I had to change the description field from text_area to text_field, something weird was going on and I couldn't change the text_area style to match the others but be a couple rows taller. 

Closes #67 