### PR TITLE
Fix new nights datepicker

### DIFF
--- a/app/controllers/couches/nights_controller.rb
+++ b/app/controllers/couches/nights_controller.rb
@@ -2,6 +2,7 @@ class Couches::NightsController < ApplicationController
 
   def new
     @night = Night.new
+    gon.available_cities = Couch.available_cities
   end
 
   def create

--- a/app/views/couches/nights/new.html.haml
+++ b/app/views/couches/nights/new.html.haml
@@ -1,6 +1,6 @@
 = form_tag(couch_nights_path, method: 'post') do
 
-  %section.dates
+  %section.dates#datepicker
     = text_field_tag "First Night", placeholder="First Night"
     = text_field_tag "Last Night", placeholder="Last Night"
 


### PR DESCRIPTION
since our jquery is setup with a function that uses gon.available_cities first, none of the following functions work without it, so i went ahead and threw it in the controller even though we don't need access to that variable

