### PR TITLE
Add explicit couch setter

### DIFF
--- a/spec/models/couch_spec.rb
+++ b/spec/models/couch_spec.rb
@@ -34,20 +34,20 @@ RSpec.describe Couch, type: :model do
     describe ".search()" do
       before do
         couch_1, couch_2, couch_3 = Couch.all[0..2]
-        couch_1.nights << create(:night, date: Date.current)
-        couch_1.nights << create(:night, date: Date.tomorrow)
+        couch_1.nights << create(:night, date: Date.current, couch: couch_1)
+        couch_1.nights << create(:night, date: Date.tomorrow, couch: couch_1)
 
-        couch_2.nights << create(:night, date: Date.current + 10.days)
+        couch_2.nights << create(:night, date: Date.current + 10.days, couch: couch_2)
 
-        last_night = build(:night, date: Date.yesterday)
+        last_night = build(:night, date: Date.yesterday, couch: couch_3)
         last_night.save(validate: false)
         couch_3.nights << last_night
-        couch_3.nights << create(:night, date: Date.current)
-        couch_3.nights << create(:night, date: Date.tomorrow)
+        couch_3.nights << create(:night, date: Date.current, couch: couch_3)
+        couch_3.nights << create(:night, date: Date.tomorrow, couch: couch_3)
       end
 
       it "returns couches for a city and date range case insensitive" do
-        params = { 
+        params = {
           "Destination" => "DENVer",
           "Check In" => Date.yesterday.to_date_picker_format,
           "Check Out" => Date.tomorrow.tomorrow.to_date_picker_format
@@ -65,7 +65,7 @@ RSpec.describe Couch, type: :model do
           "Check Out" => Date.tomorrow.tomorrow.to_date_picker_format
         }
         result = Couch.search(params)
-        
+
         expect(result.length).to eq 1
         expect(result).to be_a Couch::ActiveRecord_Relation
       end


### PR DESCRIPTION
Gremlins be gone!

The problem: shoveling in FactoryGirl objects into associations creates a default couch, then resets that couch_id to the shoveling recipient.

Solution: define the couch_id association in the factory creation.

Ready for review @njgheorghita @Sh1pley @riverswb @ski-climb 